### PR TITLE
予定apiのバックエンド実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,47 +1,49 @@
-source "https://rubygems.org"
+# frozen_string_literal: true
 
-ruby "3.2.0"
+source 'https://rubygems.org'
 
-gem "rails", "~> 7.1.5", ">= 7.1.5.1"
+ruby '3.2.0'
+
+gem 'rails', '~> 7.1.5', '>= 7.1.5.1'
 
 # データベース
-gem "mysql2", "~> 0.5"
+gem 'mysql2', '~> 0.5'
 
 # API関連のGem
-gem "devise"
-gem "devise-jwt"
-gem "rack-cors"
-gem "jsonapi-serializer"
+gem 'devise'
+gem 'devise-jwt'
+gem 'jsonapi-serializer'
+gem 'rack-cors'
 
 # Webサーバー
-gem "puma", ">= 5.0"
+gem 'puma', '>= 5.0'
 
 # Railsの基本機能
-gem "sprockets-rails"
-gem "jbuilder"
+gem 'jbuilder'
+gem 'sprockets-rails'
 
 # Windows用の設定
-gem "tzinfo-data", platforms: %i[ windows jruby ]
+gem 'tzinfo-data', platforms: %i[windows jruby]
 
 # 起動高速化
-gem "bootsnap", require: false
+gem 'bootsnap', require: false
 
 # 開発環境とテスト環境でのみ使用するGem
 group :development, :test do
-  gem "debug", platforms: %i[ mri windows ]
+  gem 'debug', platforms: %i[mri windows]
   gem 'rspec-rails', '~> 6.1'
 end
 
 # 開発環境でのみ使用するGem
 group :development do
-  gem "web-console"
   gem 'foreman'
   gem 'rubocop', require: false
   gem 'rubocop-rails', require: false
+  gem 'web-console'
 end
 
 # テスト環境でのみ使用するGem
 group :test do
-  gem "capybara"
-  gem "selenium-webdriver"
+  gem 'capybara'
+  gem 'selenium-webdriver'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,82 +1,47 @@
-# frozen_string_literal: true
+source "https://rubygems.org"
 
-source 'https://rubygems.org'
+ruby "3.2.0"
 
-ruby '3.2.0'
+gem "rails", "~> 7.1.5", ">= 7.1.5.1"
 
-# Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
-gem 'rails', '~> 7.1.5', '>= 7.1.5.1'
-
-# Use mysql2 as the database for Active Record
-gem 'mysql2', '~> 0.5'
+# データベース
+gem "mysql2", "~> 0.5"
 
 # API関連のGem
-gem 'devise'
-gem 'devise-jwt'
-gem 'jsonapi-serializer'
-gem 'rack-cors'
+gem "devise"
+gem "devise-jwt"
+gem "rack-cors"
+gem "jsonapi-serializer"
 
-# The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
-gem 'sprockets-rails'
+# Webサーバー
+gem "puma", ">= 5.0"
 
-# Use the Puma web server [https://github.com/puma/puma]
-gem 'puma', '>= 5.0'
+# Railsの基本機能
+gem "sprockets-rails"
+gem "jbuilder"
 
-# Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
-gem 'importmap-rails'
+# Windows用の設定
+gem "tzinfo-data", platforms: %i[ windows jruby ]
 
-# Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]
-gem 'turbo-rails'
-
-# Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]
-gem 'stimulus-rails'
-
-# Build JSON APIs with ease [https://github.com/rails/jbuilder]
-gem 'jbuilder'
-
-# Use Redis adapter to run Action Cable in production
-# gem "redis", ">= 4.0.1"
-
-# Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
-# gem "kredis"
-
-# Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
-# gem "bcrypt", "~> 3.1.7"
-
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: %i[windows jruby]
-
-# Reduces boot times through caching; required in config/boot.rb
-gem 'bootsnap', require: false
-
-# Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
-# gem "image_processing", "~> 1.2"
+# 起動高速化
+gem "bootsnap", require: false
 
 # 開発環境とテスト環境でのみ使用するGem
 group :development, :test do
-  # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-  gem 'debug', platforms: %i[mri windows]
+  gem "debug", platforms: %i[ mri windows ]
   gem 'rspec-rails', '~> 6.1'
 end
 
 # 開発環境でのみ使用するGem
 group :development do
-  # Use console on exceptions pages [https://github.com/rails/web-console]
+  gem "web-console"
   gem 'foreman'
   gem 'rubocop', require: false
   gem 'rubocop-rails', require: false
-  gem 'web-console'
-
-  # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]
-  # gem "rack-mini-profiler"
-
-  # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
-  # gem "spring"
 end
 
 # テスト環境でのみ使用するGem
 group :test do
-  # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
-  gem 'capybara'
-  gem 'selenium-webdriver'
+  gem "capybara"
+  gem "selenium-webdriver"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,10 +133,6 @@ GEM
       activesupport (>= 6.1)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    importmap-rails (2.1.0)
-      actionpack (>= 6.0.0)
-      activesupport (>= 6.0.0)
-      railties (>= 6.0.0)
     io-console (0.8.0)
     irb (1.15.2)
       pp (>= 0.6.0)
@@ -316,14 +312,9 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
-    stimulus-rails (1.3.4)
-      railties (>= 6.0.0)
     stringio (3.1.7)
     thor (1.3.2)
     timeout (0.4.3)
-    turbo-rails (2.0.13)
-      actionpack (>= 7.1.0)
-      railties (>= 7.1.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.1.4)
@@ -368,7 +359,6 @@ DEPENDENCIES
   devise
   devise-jwt
   foreman
-  importmap-rails
   jbuilder
   jsonapi-serializer
   mysql2 (~> 0.5)
@@ -380,8 +370,6 @@ DEPENDENCIES
   rubocop-rails
   selenium-webdriver
   sprockets-rails
-  stimulus-rails
-  turbo-rails
   tzinfo-data
   web-console
 

--- a/app/controllers/api/v1/actuals_controller.rb
+++ b/app/controllers/api/v1/actuals_controller.rb
@@ -1,2 +1,8 @@
-class Api::V1::ActualsController < ApplicationController
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class ActualsController < ApplicationController
+    end
+  end
 end

--- a/app/controllers/api/v1/actuals_controller.rb
+++ b/app/controllers/api/v1/actuals_controller.rb
@@ -1,0 +1,2 @@
+class Api::V1::ActualsController < ApplicationController
+end

--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -1,0 +1,2 @@
+class Api::V1::PlansController < ApplicationController
+end

--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -1,46 +1,52 @@
-class Api::V1::PlansController < ApplicationController
-  before_action :authenticate_user!
-  before_action :set_plan, only: %i[show update destroy]
+# frozen_string_literal: true
 
-  def index
-    date = params[:date] ? Date.parse(params[:date]) : Date.current
-    plans = current_user.plans.where(start_time: date.all_day)
-    render json: plans
-  end
+module Api
+  module V1
+    class PlansController < ApplicationController
+      before_action :authenticate_user!
+      before_action :set_plan, only: %i[show update destroy]
 
-  def show
-    render json: @plan
-  end
+      def index
+        date = params[:date] ? Date.parse(params[:date]) : Date.current
+        plans = current_user.plans.where(start_time: date.all_day)
+        render json: plans
+      end
 
-  def create
-    plan = current_user.plans.build(plan_params)
-    if plan.save
-      render json: plan, status: :created
-    else
-      render json: { errors: plan.errors.full_messages }, status: :unprocessable_entity
+      def show
+        render json: @plan
+      end
+
+      def create
+        plan = current_user.plans.build(plan_params)
+        if plan.save
+          render json: plan, status: :created
+        else
+          render json: { errors: plan.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      def update
+        if @plan.update(plan_params)
+          render json: @plan, status: :ok
+        else
+          render json: { errors: @plan.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      def destroy
+        @plan.destroy
+        head :no_content
+      end
+
+      private
+
+      def set_plan
+        @plan = current_user.plans.find(params[:id])
+      end
+
+      def plan_params
+        params.require(:plan).permit(:memo, :start_time, :end_time, :category_id)
+      end
     end
-  end
-
-  def update
-    if @plan.update(plan_params)
-      render json: @plan, status: :ok
-    else
-      render json: { errors: @plan.errors.full_messages }, status: :unprocessable_entity
-    end
-  end
-
-  def destroy
-    @plan.destroy
-    head :no_content
-  end
-
-  private
-
-  def set_plan
-    @plan = current_user.plans.find(params[:id])
-  end
-
-  def plan_params
-    params.require(:plan).permit(:memo, :start_time, :end_time, :category_id)
   end
 end

--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -1,2 +1,7 @@
 class Api::V1::PlansController < ApplicationController
+  before_action :authenticate_user!
+  def index
+    plans = current_user.plans
+    render json: plans
+  end
 end

--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -5,4 +5,20 @@ class Api::V1::PlansController < ApplicationController
     plans = current_user.plans.where(start_time: date.all_day)
     render json: plans
   end
+
+  def create
+    plan = current_user.plans.build(plan_params)
+
+    if plan.save
+      render json: plan, status: :created
+    else
+      render json: { errors: plan.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def plan_params
+    params.require(:plan).permit(:memo, :start_time, :end_time, :category_id)
+  end
 end

--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -1,5 +1,7 @@
 class Api::V1::PlansController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_plan, only: %i[show update]
+
   def index
     date = params[:date] ? Date.parse(params[:date]) : Date.current
     plans = current_user.plans.where(start_time: date.all_day)
@@ -7,13 +9,11 @@ class Api::V1::PlansController < ApplicationController
   end
 
   def show
-    @plan = current_user.plans.find(params[:id])
     render json: @plan
   end
 
   def create
     plan = current_user.plans.build(plan_params)
-
     if plan.save
       render json: plan, status: :created
     else
@@ -21,7 +21,19 @@ class Api::V1::PlansController < ApplicationController
     end
   end
 
+  def update
+    if @plan.update(plan_params)
+      render json: @plan, status: :ok
+    else
+      render json: { errors: @plan.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
   private
+
+  def set_plan
+    @plan = current_user.plans.find(params[:id])
+  end
 
   def plan_params
     params.require(:plan).permit(:memo, :start_time, :end_time, :category_id)

--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -6,6 +6,11 @@ class Api::V1::PlansController < ApplicationController
     render json: plans
   end
 
+  def show
+    @plan = current_user.plans.find(params[:id])
+    render json: @plan
+  end
+
   def create
     plan = current_user.plans.build(plan_params)
 

--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -1,7 +1,8 @@
 class Api::V1::PlansController < ApplicationController
   before_action :authenticate_user!
   def index
-    plans = current_user.plans
+    date = params[:date] ? Date.parse(params[:date]) : Date.current
+    plans = current_user.plans.where(start_time: date.all_day)
     render json: plans
   end
 end

--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::PlansController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_plan, only: %i[show update]
+  before_action :set_plan, only: %i[show update destroy]
 
   def index
     date = params[:date] ? Date.parse(params[:date]) : Date.current
@@ -27,6 +27,11 @@ class Api::V1::PlansController < ApplicationController
     else
       render json: { errors: @plan.errors.full_messages }, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    @plan.destroy
+    head :no_content
   end
 
   private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ApplicationController < ActionController::API # APIモードなので :API を継承
+class ApplicationController < ActionController::API
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   protected

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-class EventsController < ApplicationController
-  def index; end
-end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -16,7 +16,6 @@ module Users
       end
       self.resource = warden.authenticate(auth_options)
       if resource
-        sign_in(resource_name, resource)
         render json: {
           status: { code: 200, message: 'Logged in successfully.' },
           data: UserSerializer.new(resource).serializable_hash[:data][:attributes]
@@ -37,7 +36,6 @@ module Users
       end
 
       if current_user
-        sign_out(current_user)
         render json: {
           status: 200,
           message: 'Logged out successfully.'

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,2 +1,0 @@
-<h1>Events#index</h1>
-<p>Find me in app/views/events/index.html.erb</p>

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,8 @@ module Schedpoint
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.1
 
+    config.api_only = true
+
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -97,7 +97,7 @@ Devise.setup do |config|
   # Notice that if you are skipping storage for all authentication paths, you
   # may want to disable generating routes to Devise's sessions controller by
   # passing skip: :sessions to `devise_for` in your config/routes.rb
-  config.skip_session_storage = [:http_auth]
+  config.skip_session_storage = [:http_auth, :session]
 
   # By default, Devise cleans up the CSRF token on authentication to
   # avoid CSRF token fixation attacks. This means that, when using AJAX
@@ -263,7 +263,7 @@ Devise.setup do |config|
   # should add them to the navigational formats lists.
   #
   # The "*/*" below is required to match Internet Explorer requests.
-  # config.navigational_formats = ['*/*', :html, :turbo_stream]
+  config.navigational_formats = []
 
   # The default HTTP method used to sign out a resource. Default is :delete.
   config.sign_out_via = :delete

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,11 @@ Rails.application.routes.draw do
     registrations: 'users/registrations',
     sessions: 'users/sessions'
   }
-  # get 'events/index'
-  # root to: "events#index"
+
+  namespace :api do
+    namespace :v1 do
+      resources :plans, only: [:index, :create, :show, :update, :destroy]
+      resources :actuals, only: [:index, :create, :show, :update, :destroy]
+    end
+  end
 end

--- a/spec/requests/api/v1/actuals_spec.rb
+++ b/spec/requests/api/v1/actuals_spec.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
-RSpec.describe "Api::V1::Actuals", type: :request do
-  describe "GET /index" do
+RSpec.describe 'Api::V1::Actuals', type: :request do
+  describe 'GET /index' do
     pending "add some examples (or delete) #{__FILE__}"
   end
 end

--- a/spec/requests/api/v1/actuals_spec.rb
+++ b/spec/requests/api/v1/actuals_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Actuals", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/api/v1/plans_spec.rb
+++ b/spec/requests/api/v1/plans_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Plans", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/api/v1/plans_spec.rb
+++ b/spec/requests/api/v1/plans_spec.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
-RSpec.describe "Api::V1::Plans", type: :request do
-  describe "GET /index" do
+RSpec.describe 'Api::V1::Plans', type: :request do
+  describe 'GET /index' do
     pending "add some examples (or delete) #{__FILE__}"
   end
 end


### PR DESCRIPTION
# What

アプリケーションのコア機能である「予定（Plan）」を管理するための、バックエンドAPIを実装した。
具体的なタスクは以下のとおり。

- **コントローラーとルーティングの設計**
  - `api/v1`の名前空間を導入し、`PlansController`と`ActualsController`を生成
  - `config/routes.rb`に、`plans`と`actuals`リソースのRESTfulなルーティングを設定

- **`PlansController`へのCRUD機能実装**
  - `index`: ログインユーザーの、特定の日付の予定一覧を返すAPIを実装
  - `create`: 新しい予定を作成し、ログインユーザーに紐付けて保存するAPIを実装
  - `show`: 特定の予定を一件取得するAPIを実装
  - `update`: 既存の予定を更新するAPIを実装
  - `destroy`: 既存の予定を削除するAPIを実装

- **認証と認可**
  - `before_action :authenticate_user!`を用いて、全てのAPIがログイン必須であることを保証
  - `current_user`を起点にデータを操作することで、ユーザーが自身の予定しか閲覧・操作できないように認可処理を実装

- **APIのテストとデバッグ**
  - Postmanを使い、実装した全てのAPIエンドポイントについて、正常系（200 OKなど）と異常系（401 Unauthorized, 404 Not Found, 422 Unprocessable Entityなど）のテストを完了
  - APIモードにおけるセッション・Cookie起因の認証バグを根本的に解決し、JWTトークンのみで認証を行う完全なステートレスAPIを実現

# Why

今後、フロントエンド側でカレンダーに予定を表示したり、新しい予定を作成したりする機能を実現するための、バックエンド側のデータ送受信の窓口が必要となるため。
このAPIが完成したことにより、フロントエンドはユーザーの予定データを安全に操作できるようになる。

## 補足

- `ActualsController`は、今後の実装のためにファイルのみ生成済みで、中身は未実装です。
- 不要になった`events_controller`は、関連ファイルも含めて削除済みです。