### PR TITLE
予定APIのフロントエンド実装

### DIFF
--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -8,6 +8,7 @@
 
 - **ユーザー認証**: 新規登録、ログイン、ログアウト機能。
 - **予定・実績の CRUD 管理**: カレンダー形式の UI で、日々の予定と、実際に行動した実績を記録・閲覧・更新・削除する機能。
+- **カテゴリ管理**: 予定や実績を分類するためのカテゴリ機能。
 
 ### 2. 技術スタック
 
@@ -22,7 +23,7 @@
   - `devise`, `devise-jwt`: トークンベースの API 認証
   - `rspec-rails`: テストフレームワーク
   - `rack-cors`: CORS（クロスオリジンリソース共有）設定
-  - `jsonapi-serializer`: 安全な JSON レスポンスの生成
+  - `jsonapi-serializer`: 安全で一貫性のある JSON レスポンスの生成
   - `puma`: Web サーバー
   - `rubocop`, `rubocop-rails`: 静的コード解析・フォーマッター
 
@@ -32,13 +33,13 @@
 - **状態管理**: Pinia
 - **HTTP クライアント**: Axios
 - **ルーティング**: Vue Router
-- **UI/スタイリング**: Tailwind CSS
+- **UI/スタイリング**: Tailwind CSS, Font Awesome
 - **コードフォーマッター**: Prettier
 
 ### 3. データベーススキーマ
 
 ```ruby
-ActiveRecord::Schema[7.1].define(version: 2025_07_14_031635) do
+ActiveRecord::Schema[7.1].define(version: 2025_07_25_120000) do
   create_table "actuals", charset: "utf8mb3", force: :cascade do |t|
     t.text "memo"
     t.datetime "start_time", null: false
@@ -53,6 +54,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_14_031635) do
 
   create_table "categories", charset: "utf8mb3", force: :cascade do |t|
     t.string "name", null: false
+    t.string "icon"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_categories_on_name", unique: true
@@ -148,6 +150,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :plans, only: [:index, :create, :show, :update, :destroy]
       resources :actuals, only: [:index, :create, :show, :update, :destroy]
+      resources :categories, only: [:index]
     end
   end
 end
@@ -161,6 +164,15 @@ end
 - **API 設計**:
   - 将来の拡張性を考慮し、`api/v1/`のように**バージョンを明記した RESTful API**として設計。
   - コア機能は`EventsController`で一つにまとめるのではなく、責務を明確にするため`PlansController`と`ActualsController`に分割。
-- **タイムゾーン**: バックエンドは**UTC**で時刻を管理し、フロントエンド側で**日本時間（JST）**に変換して表示する、グローバルスタンダードな方式を採用。
+  - **API レスポンスの統一**: `jsonapi-serializer`を全面的に採用し、すべての API エンドポイントで構造化された JSON を返すように設計。これによりフロントエンドでのデータハンドリングを簡素化し、保守性を向上。
+- **データの一貫性**: `db/seeds.rb` を活用し、アプリケーションの初期データ（カテゴリ一覧など）を定義。これにより、どの開発環境でも同じデータでアプリケーションを起動できる状態を担保。
+- **タイムゾーン**: バックエンドは**UTC**で時刻を管理し、フロントエンド側で日本時間（JST）に変換して表示する、グローバルスタンダードな方式を採用。
 - **テスト**: バックエンド API の動作確認は**Postman**で実施。テストフレームワークとして**RSpec**を導入済み。
 - **コード品質**: `RuboCop`と`Prettier`を導入し、保存時の自動整形を設定することで、コードの品質と一貫性を担保。
+
+### 7. 現在の状況と次のタスク
+
+- **【完了】** ユーザー認証機能（新規登録、ログイン、ログアウト）
+- **【完了】** 「予定」の CRUD 管理機能（一覧表示、新規作成）
+- **【TODO】** 「予定」の更新・削除機能の実装
+- **【TODO】** 「実績」の CRUD 管理機能の実装（「予定」の実装を参考に進める）

--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -1,0 +1,166 @@
+# SchedPoint プロジェクトサマリー
+
+### 1. アプリケーションの概要
+
+`SchedPoint`は、日々の「予定」と「実績」を時間軸上で可視化し、比較・分析することで、ユーザーの時間管理能力の向上をサポートする Web アプリケーションです。
+
+**主要な機能:**
+
+- **ユーザー認証**: 新規登録、ログイン、ログアウト機能。
+- **予定・実績の CRUD 管理**: カレンダー形式の UI で、日々の予定と、実際に行動した実績を記録・閲覧・更新・削除する機能。
+
+### 2. 技術スタック
+
+モダンな Web 開発で標準的な、バックエンドとフロントエンドを完全に分離した**SPA（シングルページアプリケーション）**構成を採用しています。
+
+#### バックエンド
+
+- **Ruby**: `3.2.0`
+- **Rails**: `7.1.5` (API モード)
+- **データベース**: MySQL
+- **主要な Gem**:
+  - `devise`, `devise-jwt`: トークンベースの API 認証
+  - `rspec-rails`: テストフレームワーク
+  - `rack-cors`: CORS（クロスオリジンリソース共有）設定
+  - `jsonapi-serializer`: 安全な JSON レスポンスの生成
+  - `puma`: Web サーバー
+  - `rubocop`, `rubocop-rails`: 静的コード解析・フォーマッター
+
+#### フロントエンド
+
+- **フレームワーク**: Vue.js 3 (Composition API)
+- **状態管理**: Pinia
+- **HTTP クライアント**: Axios
+- **ルーティング**: Vue Router
+- **UI/スタイリング**: Tailwind CSS
+- **コードフォーマッター**: Prettier
+
+### 3. データベーススキーマ
+
+```ruby
+ActiveRecord::Schema[7.1].define(version: 2025_07_14_031635) do
+  create_table "actuals", charset: "utf8mb3", force: :cascade do |t|
+    t.text "memo"
+    t.datetime "start_time", null: false
+    t.datetime "end_time", null: false
+    t.bigint "user_id", null: false
+    t.bigint "category_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category_id"], name: "index_actuals_on_category_id"
+    t.index ["user_id"], name: "index_actuals_on_user_id"
+  end
+
+  create_table "categories", charset: "utf8mb3", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_categories_on_name", unique: true
+  end
+
+  create_table "plans", charset: "utf8mb3", force: :cascade do |t|
+    t.text "memo"
+    t.datetime "start_time", null: false
+    t.datetime "end_time", null: false
+    t.bigint "user_id", null: false
+    t.bigint "category_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category_id"], name: "index_plans_on_category_id"
+    t.index ["user_id"], name: "index_plans_on_user_id"
+  end
+
+  create_table "users", charset: "utf8mb3", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "jti", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["jti"], name: "index_users_on_jti", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  end
+
+  add_foreign_key "actuals", "categories"
+  add_foreign_key "actuals", "users"
+  add_foreign_key "plans", "categories"
+  add_foreign_key "plans", "users"
+end
+```
+
+### 4. 主要なモデルのコード
+
+※ `app/models/`配下のファイル内容です。
+
+**`user.rb`**
+
+```ruby
+# frozen_string_literal: true
+
+class User < ApplicationRecord
+  # Include default devise modules. Others available are:
+  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  include Devise::JWT::RevocationStrategies::JTIMatcher
+
+  devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable, :validatable,
+         :jwt_authenticatable, jwt_revocation_strategy: self
+
+  has_many :plans, dependent: :destroy
+  has_many :actuals, dependent: :destroy
+
+  validates :name, presence: true
+end
+```
+
+**`plan.rb`**
+
+```ruby
+class Plan < ApplicationRecord
+  belongs_to :user
+  belongs_to :category
+end
+```
+
+**`category.rb`**
+
+```ruby
+class Category < ApplicationRecord
+  has_many :plans, dependent: :destroy
+  has_many :actuals, dependent: :destroy
+end
+```
+
+### 5. ルーティング (config/routes.rb)
+
+```ruby
+Rails.application.routes.draw do
+  devise_for :users, controllers: {
+    registrations: 'users/registrations',
+    sessions: 'users/sessions'
+  }
+
+  namespace :api do
+    namespace :v1 do
+      resources :plans, only: [:index, :create, :show, :update, :destroy]
+      resources :actuals, only: [:index, :create, :show, :update, :destroy]
+    end
+  end
+end
+```
+
+### 6. 重要な決定事項
+
+- **アーキテクチャ**: 当初は通常の Rails アプリとして開発を開始したが、途中から**Rails を API モード**、**フロントエンドを Vue.js による SPA**とする構成に方針転換。
+- **UI/UX**: MVP（Minimum Viable Product）段階では、PC の画面サイズでも視認性を確保するため、当初の「週間表示」から\*\*「1 日表示」\*\*に表示単位を絞ることを決定。
+- **認証**: `devise`と`devise-jwt`を使用し、セッションに依存しない**ステートレスな JWT 認証**を実装。
+- **API 設計**:
+  - 将来の拡張性を考慮し、`api/v1/`のように**バージョンを明記した RESTful API**として設計。
+  - コア機能は`EventsController`で一つにまとめるのではなく、責務を明確にするため`PlansController`と`ActualsController`に分割。
+- **タイムゾーン**: バックエンドは**UTC**で時刻を管理し、フロントエンド側で**日本時間（JST）**に変換して表示する、グローバルスタンダードな方式を採用。
+- **テスト**: バックエンド API の動作確認は**Postman**で実施。テストフレームワークとして**RSpec**を導入済み。
+- **コード品質**: `RuboCop`と`Prettier`を導入し、保存時の自動整形を設定することで、コードの品質と一貫性を担保。

--- a/app/controllers/api/v1/categories_controller.rb
+++ b/app/controllers/api/v1/categories_controller.rb
@@ -1,0 +1,9 @@
+class Api::V1::CategoriesController < ApplicationController
+  before_action :authenticate_user! # ログインしているユーザーのみアクセス可能
+
+  def index
+    categories = Category.all.order(:id) # id順で並び替えて取得
+    # CategorySerializerを使ってJSONを返す
+    render json: Api::V1::CategorySerializer.new(categories).serializable_hash
+  end
+end

--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -20,13 +20,13 @@ module Api
       end
 
       def show
-        render json: @plan
+        render json: Api::V1::PlanSerializer.new(@plan).serializable_hash
       end
 
       def create
         plan = current_user.plans.build(plan_params)
         if plan.save
-          render json: plan, status: :created
+          render json: Api::V1::PlanSerializer.new(plan).serializable_hash, status: :created
         else
           render json: { errors: plan.errors.full_messages }, status: :unprocessable_entity
         end
@@ -34,7 +34,7 @@ module Api
 
       def update
         if @plan.update(plan_params)
-          render json: @plan, status: :ok
+          render json: Api::V1::PlanSerializer.new(@plan).serializable_hash, status: :ok
         else
           render json: { errors: @plan.errors.full_messages }, status: :unprocessable_entity
         end

--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -8,7 +8,11 @@ module Api
 
       def index
         date = params[:date] ? Date.parse(params[:date]) : Date.current
-        plans = current_user.plans.includes(:category).where(start_time: date.all_day)
+
+        day_start = date.beginning_of_day
+        day_end = date.end_of_day
+
+        plans = current_user.plans.includes(:category).where('start_time <= ? AND end_time >= ?', day_end, day_start)
         render json: plans.as_json(include: { category: { only: %i[id name] } })
       end
 

--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -13,7 +13,10 @@ module Api
         day_end = date.end_of_day
 
         plans = current_user.plans.includes(:category).where('start_time <= ? AND end_time >= ?', day_end, day_start)
-        render json: plans.as_json(include: { category: { only: %i[id name] } })
+        # シリアライザを呼び出すためのオプション
+        # これでPlanに紐づくCategoryの情報も含めてくれます
+        options = { include: [:category] }
+        render json: Api::V1::PlanSerializer.new(plans, options).serializable_hash
       end
 
       def show

--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -8,8 +8,8 @@ module Api
 
       def index
         date = params[:date] ? Date.parse(params[:date]) : Date.current
-        plans = current_user.plans.where(start_time: date.all_day)
-        render json: plans
+        plans = current_user.plans.includes(:category).where(start_time: date.all_day)
+        render json: plans.as_json(include: { category: { only: %i[id name] } })
       end
 
       def show

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -8,10 +8,7 @@ module Users
       build_resource(sign_up_params)
 
       if resource.save
-        render json: {
-          status: { code: 200, message: 'Signed up successfully.' },
-          data: UserSerializer.new(resource).serializable_hash[:data][:attributes]
-        }
+        render json: Api::V1::UserSerializer.new(resource).serializable_hash, status: :created
       else
         render json: {
           status: { message: "User couldn't be created successfully. #{resource.errors.full_messages.to_sentence}" }

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -8,18 +8,12 @@ module Users
 
     def create
       if user_signed_in?
-        render json: {
-          status: { code: 200, message: 'You are already logged in.' },
-          data: UserSerializer.new(current_user).serializable_hash[:data][:attributes]
-        }
+        render json: Api::V1::UserSerializer.new(current_user).serializable_hash, status: :ok
         return
       end
       self.resource = warden.authenticate(auth_options)
       if resource
-        render json: {
-          status: { code: 200, message: 'Logged in successfully.' },
-          data: UserSerializer.new(resource).serializable_hash[:data][:attributes]
-        }
+        render json: Api::V1::UserSerializer.new(resource).serializable_hash, status: :ok
       else
         render json: {
           status: 401,

--- a/app/serializers/api/v1/category_serializer.rb
+++ b/app/serializers/api/v1/category_serializer.rb
@@ -1,0 +1,5 @@
+# app/serializers/api/v1/category_serializer.rb
+class Api::V1::CategorySerializer
+  include JSONAPI::Serializer
+  attributes :id, :name
+end

--- a/app/serializers/api/v1/category_serializer.rb
+++ b/app/serializers/api/v1/category_serializer.rb
@@ -1,5 +1,5 @@
 # app/serializers/api/v1/category_serializer.rb
 class Api::V1::CategorySerializer
   include JSONAPI::Serializer
-  attributes :id, :name
+  attributes :id, :name, :icon
 end

--- a/app/serializers/api/v1/plan_serializer.rb
+++ b/app/serializers/api/v1/plan_serializer.rb
@@ -1,0 +1,12 @@
+# app/serializers/api/v1/plan_serializer.rb
+
+class Api::V1::PlanSerializer
+  include JSONAPI::Serializer
+
+  # 1. フロントエンドに渡したいカラム名を指定
+  attributes :id, :memo, :start_time, :end_time
+
+  # 2. 関連するモデルの情報も渡す場合は、ここで関連を定義
+  # これにより、Categoryの情報も一緒に含めることができる
+  belongs_to :category
+end

--- a/app/serializers/api/v1/user_serializer.rb
+++ b/app/serializers/api/v1/user_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class UserSerializer
+class Api::V1::UserSerializer
   include JSONAPI::Serializer
-  attributes :name, :email
+  attributes :id, :name, :email
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,5 +36,6 @@ module Schedpoint
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+    config.time_zone = 'Tokyo'
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :plans, only: [:index, :create, :show, :update, :destroy]
       resources :actuals, only: [:index, :create, :show, :update, :destroy]
+      resources :categories, only: [:index]
     end
   end
 end

--- a/db/migrate/20250725011855_add_icon_to_categories.rb
+++ b/db/migrate/20250725011855_add_icon_to_categories.rb
@@ -1,0 +1,5 @@
+class AddIconToCategories < ActiveRecord::Migration[7.1]
+  def change
+    add_column :categories, :icon, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_07_14_031635) do
+ActiveRecord::Schema[7.1].define(version: 2025_07_25_011855) do
   create_table "actuals", charset: "utf8mb3", force: :cascade do |t|
     t.text "memo"
     t.datetime "start_time", null: false
@@ -27,6 +27,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_14_031635) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "icon"
     t.index ["name"], name: "index_categories_on_name", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,11 +1,36 @@
 # frozen_string_literal: true
 
-# This file should ensure the existence of records required to run the application in every environment (production,
-# development, test). The code here should be idempotent so that it can be executed at any point in every environment.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Example:
-#
-#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
-#   end
+# 既存のカテゴリデータを一度すべて削除する
+puts 'Destroying all categories...'
+Category.destroy_all
+
+# 登録したいカテゴリデータの配列
+# フロントエンドのアイコン配列 ['fas', 'bed'] を、スペース区切りの文字列 "fas bed" として保存する
+categories = [
+  { name: '睡眠', icon: 'fas bed' },
+  { name: '食事', icon: 'fas utensils' },
+  { name: 'お風呂', icon: 'fas bath' },
+  { name: '移動', icon: 'fas train' },
+  { name: '仕事', icon: 'fas briefcase' },
+  { name: '学校', icon: 'fas school' },
+  { name: '勉強', icon: 'fas book-open' },
+  { name: 'スマホ', icon: 'fas mobile-alt' },
+  { name: 'PC', icon: 'fas laptop' },
+  { name: '遊ぶ', icon: 'fas music' },
+  { name: 'ゲーム', icon: 'fas gamepad' },
+  { name: 'TV', icon: 'fas tv' },
+  { name: '映画', icon: 'fas film' },
+  { name: '読書', icon: 'fas book' },
+  { name: 'スポーツ', icon: 'fas futbol' },
+  { name: '買い物', icon: 'fas shopping-cart' },
+  { name: 'カフェ', icon: 'fas mug-saucer' },
+  { name: '飲み会', icon: 'fas beer-mug-empty' }
+]
+
+# 配列のデータを一つずつデータベースに登録する
+puts 'Creating categories...'
+categories.each do |category|
+  Category.create!(category)
+end
+
+puts "Created #{Category.count} categories."

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,18 +1,15 @@
 <script setup>
 import { onMounted } from 'vue'
-import { useAuthStore } from './stores/auth'
+import { useAuthStore } from '@/stores/auth'
 
 // アプリ起動時に一度だけ、ログイン状態を復元する処理を呼び出す
 const authStore = useAuthStore()
+
 onMounted(() => {
   authStore.initialize()
 })
 </script>
 
 <template>
-  <main>
-    <router-view />
-  </main>
+  <router-view />
 </template>
-
-<style scoped></style>

--- a/frontend/src/components/CategorySelector.vue
+++ b/frontend/src/components/CategorySelector.vue
@@ -1,37 +1,42 @@
 <script setup>
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 
-// 親コンポーネントに選択されたカテゴリを伝えるためのemit関数を定義
-const emit = defineEmits(['update:selectedCategory'])
+// 親からカテゴリ一覧を受け取るための「props」を定義
+const props = defineProps({
+  categories: {
+    type: Array,
+    required: true,
+  },
+  // 親コンポーネントと選択されたカテゴリを双方向で連携させるための設定 (v-model用)
+  modelValue: {
+    type: Object, // 文字列ではなく、カテゴリのオブジェクト全体を受け取る
+    default: null,
+  },
+})
 
-// 仮のカテゴリデータ
-const categories = ref([
-  { name: '睡眠', icon: ['fas', 'bed'] },
-  { name: '食事', icon: ['fas', 'utensils'] },
-  { name: 'お風呂', icon: ['fas', 'bath'] },
-  { name: '移動', icon: ['fas', 'train'] },
-  { name: '仕事', icon: ['fas', 'briefcase'] },
-  { name: '学校', icon: ['fas', 'school'] },
-  { name: '勉強', icon: ['fas', 'book-open'] },
-  { name: 'スマホ', icon: ['fas', 'mobile-alt'] },
-  { name: 'PC', icon: ['fas', 'laptop'] },
-  { name: '遊ぶ', icon: ['fas', 'music'] },
-  { name: 'ゲーム', icon: ['fas', 'gamepad'] },
-  { name: 'TV', icon: ['fas', 'tv'] },
-  { name: '映画', icon: ['fas', 'film'] },
-  { name: '読書', icon: ['fas', 'book'] },
-  { name: 'スポーツ', icon: ['fas', 'futbol'] },
-  { name: '買い物', icon: ['fas', 'shopping-cart'] },
-  { name: 'カフェ', icon: ['fas', 'mug-saucer'] },
-  { name: '飲み会', icon: ['fas', 'beer-mug-empty'] },
-])
-const selectedCategory = ref('')
+// 親コンポーネントに選択内容の変更を伝えるための「emit」を定義
+const emit = defineEmits(['update:modelValue'])
+
+// 選択されているカテゴリのオブジェクトを保持する
+const selectedCategory = ref(props.modelValue)
+
+// 親のデータ(modelValue)が変わったときに、子のデータ(selectedCategory)も更新する
+watch(
+  () => props.modelValue,
+  (newValue) => {
+    selectedCategory.value = newValue
+  },
+)
 // カテゴリがクリックされたときの処理
-const selectCategory = (categoryName) => {
-  // 既に選択されている場合は選択を解除、そうでない場合は選択
-  selectedCategory.value = selectedCategory.value === categoryName ? '' : categoryName
-  // 親コンポーネントに選択されたカテゴリをemitで伝える
-  emit('update:selectedCategory', selectedCategory.value)
+const selectCategory = (category) => {
+  // すでに選択されているカテゴリをもう一度クリックしたら、選択を解除する
+  if (selectedCategory.value && selectedCategory.value.id === category.id) {
+    selectedCategory.value = null
+  } else {
+    selectedCategory.value = category
+  }
+  // 親コンポーネントに、選択されたカテゴリの「オブジェクト」を伝える
+  emit('update:modelValue', selectedCategory.value)
 }
 </script>
 
@@ -40,16 +45,21 @@ const selectCategory = (categoryName) => {
     <label class="block text-gray-700 text-sm font-bold mb-2">カテゴリ</label>
     <div class="grid grid-cols-6 gap-8">
       <div
-        v-for="category in categories"
-        :key="category.name"
+        v-for="category in props.categories"
+        :key="category.id"
         class="flex flex-col items-center p-3 border rounded-lg cursor-pointer"
         :class="{
-          'bg-blue-200 border-blue-500': selectedCategory === category.name,
-          'bg-gray-50 hover:bg-gray-100 border-gray-300': selectedCategory !== category.name,
+          'bg-blue-200 border-blue-500': selectedCategory && selectedCategory.id === category.id,
+          'bg-gray-50 hover:bg-gray-100 border-gray-300':
+            !selectedCategory || selectedCategory.id !== category.id,
         }"
-        @click="selectCategory(category.name)"
+        @click="selectCategory(category)"
       >
-        <font-awesome-icon :icon="category.icon" class="text-3xl mb-1" />
+        <font-awesome-icon
+          v-if="category.icon"
+          :icon="category.icon.split(' ')"
+          class="text-3xl mb-1"
+        />
         <span class="text-sm text-center font-medium">{{ category.name }}</span>
       </div>
     </div>

--- a/frontend/src/components/ScheduleColumn.vue
+++ b/frontend/src/components/ScheduleColumn.vue
@@ -15,6 +15,14 @@ const SLOT_HEIGHT = 48
 // h2タグの高さ (h-16 = 64px)
 const HEADER_HEIGHT = 64
 
+const formatTime = (date) => {
+  if (!date || !(date instanceof Date)) return ''
+  // getHours()とgetMinutes()はブラウザのローカルタイム（日本時間）を返すので、ここでタイムゾーンが正しく扱われます
+  const hours = date.getHours().toString().padStart(2, '0')
+  const minutes = date.getMinutes().toString().padStart(2, '0')
+  return `${hours}:${minutes}`
+}
+
 // イベントのスタイルを計算する関数
 const getEventStyle = (event) => {
   // 開始時刻を基準にtopを計算
@@ -47,8 +55,8 @@ const getEventStyle = (event) => {
     <EventBlock
       v-for="event in events"
       :key="event.id"
-      :category-name="event.category"
-      :time="`${event.startTime.getHours().toString().padStart(2, '0')}:${event.startTime.getMinutes().toString().padStart(2, '0')} - ${event.endTime.getHours().toString().padStart(2, '0')}:${event.endTime.getMinutes().toString().padStart(2, '0')}`"
+      :category-name="event.category?.name || event.memo"
+      :time="`${formatTime(event.startTime)} - ${formatTime(event.endTime)}`"
       :style="getEventStyle(event)"
     />
   </div>

--- a/frontend/src/components/TheHeader.vue
+++ b/frontend/src/components/TheHeader.vue
@@ -2,8 +2,10 @@
 import { ref, onMounted, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
+import { usePlanStore } from '@/stores/plan'
 
 const authStore = useAuthStore()
+const planStore = usePlanStore()
 const router = useRouter()
 
 const isDropdownOpen = ref(false)
@@ -39,18 +41,23 @@ const handleLogout = () => {
 <template>
   <div class="container mx-auto flex items-center justify-between h-full px-4 py-3">
     <div class="flex items-center">
-      <div class="text-2xl mr-8 text-gray-800">2025年6月26日</div>
+      <div class="text-2xl mr-8 text-gray-800">{{ planStore.formattedCurrentDate }}</div>
       <button
+        @click="planStore.resetToToday()"
         class="bg-gray-200 hover:bg-gray-300 text-gray-800 font-bold text-xl py-2 px-4 rounded-lg mr-6"
       >
         今日
       </button>
       <button
+        @click="planStore.changeDate(-1)"
         class="bg-gray-200 hover:bg-gray-300 text-gray-800 font-bold py-2 px-4 rounded-lg mr-4"
       >
         前日
       </button>
-      <button class="bg-gray-200 hover:bg-gray-300 text-gray-800 font-bold py-2 px-4 rounded-lg">
+      <button
+        @click="planStore.changeDate(1)"
+        class="bg-gray-200 hover:bg-gray-300 text-gray-800 font-bold py-2 px-4 rounded-lg"
+      >
         翌日
       </button>
     </div>

--- a/frontend/src/stores/plan.js
+++ b/frontend/src/stores/plan.js
@@ -1,0 +1,12 @@
+import { defineStore } from 'pinia'
+import axios from 'axios'
+
+export const usePlanStore = defineStore('plan', {
+  state: () => ({
+    plans: [],
+  }),
+
+  getters: {},
+
+  actions: {},
+})

--- a/frontend/src/stores/plan.js
+++ b/frontend/src/stores/plan.js
@@ -15,7 +15,16 @@ export const usePlanStore = defineStore('plan', {
     async fetchPlans(date) {
       try {
         const response = await axios.get(`http://localhost:3000/api/v1/plans?date=${date}`)
-        this.plans = response.data
+
+        const formattedPlans = response.data.map((plan) => {
+          return {
+            ...plan,
+            startTime: new Date(plan.start_time),
+            endTime: new Date(plan.end_time),
+          }
+        })
+
+        this.plans = formattedPlans
       } catch (error) {
         console.error('予定の取得に失敗しました:', error)
         this.plans = []

--- a/frontend/src/stores/plan.js
+++ b/frontend/src/stores/plan.js
@@ -2,7 +2,14 @@ import { defineStore } from 'pinia'
 import axios from 'axios'
 
 // 'YYYY-MM-DD'形式の、今日の日付文字列を返すヘルパー関数
-const getTodayString = () => new Date().toISOString().split('T')[0]
+const getTodayString = () => {
+  const today = new Date() // PCのローカルタイム（日本時間）でDateオブジェクトを生成
+  const year = today.getFullYear() // 年を取得
+  const month = String(today.getMonth() + 1).padStart(2, '0') // 月を取得（0から始まるので+1する）
+  const day = String(today.getDate()).padStart(2, '0') // 日を取得
+
+  return `${year}-${month}-${day}` // 'YYYY-MM-DD'形式の文字列を組み立てて返す
+}
 
 export const usePlanStore = defineStore('plan', {
   state: () => ({

--- a/frontend/src/stores/plan.js
+++ b/frontend/src/stores/plan.js
@@ -8,5 +8,18 @@ export const usePlanStore = defineStore('plan', {
 
   getters: {},
 
-  actions: {},
+  actions: {
+    /**
+     * @param {string} date
+     */
+    async fetchPlans(date) {
+      try {
+        const response = await axios.get(`http://localhost:3000/api/v1/plans?date=${date}`)
+        this.plans = response.data
+      } catch (error) {
+        console.error('予定の取得に失敗しました:', error)
+        this.plans = []
+      }
+    },
+  },
 })

--- a/frontend/src/views/EventFormView.vue
+++ b/frontend/src/views/EventFormView.vue
@@ -1,27 +1,54 @@
 <script setup>
-import { ref } from 'vue'
+import { ref, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { usePlanStore } from '@/stores/plan'
+import { useAuthStore } from '@/stores/auth'
 import CategorySelector from '@/components/CategorySelector.vue'
 
-// フォームの各入力フィールドに対応するリアクティブなデータ
-const category = ref('') // CategorySelectorからの選択を受け取る
-const startTime = ref('') //
-const endTime = ref('') //
-const memo = ref('') //
+const router = useRouter()
+const planStore = usePlanStore()
+const authStore = useAuthStore()
 
-// CategorySelectorから選択されたカテゴリを受け取るハンドラ
-const handleCategoryUpdate = (selectedCat) => {
-  category.value = selectedCat
-  console.log('選択されたカテゴリ:', category.value)
-}
+// フォームの各入力フィールドに対応するリアクティブなデータ
+const selectedCategoryObject = ref(null) // CategorySelectorからの選択を受け取る
+const startTime = ref('')
+const endTime = ref('')
+const memo = ref('')
+
+// コンポーネントが表示されたときにカテゴリを取得する
+onMounted(() => {
+  // もしストアにカテゴリがなければ取得する
+  if (authStore.categories.length === 0) {
+    authStore.fetchCategories()
+  }
+})
 
 // フォーム送信時の処理
-const handleSubmit = () => {
-  console.log('フォームが送信されました:', {
-    category: category.value,
-    startTime: startTime.value,
-    endTime: endTime.value,
+const handleSubmit = async () => {
+  // バリデーション: カテゴリが選択されているか確認
+  if (!selectedCategoryObject.value || !selectedCategoryObject.value.id) {
+    alert('カテゴリを選択してください。') // 本来はアラートではなく、UIでエラー表示するのが望ましい
+    return
+  }
+
+  // APIに送信するデータを作成
+  const planData = {
+    category_id: selectedCategoryObject.value.id, // カテゴリオブジェクトからIDを取り出す
+    start_time: startTime.value,
+    end_time: endTime.value,
     memo: memo.value,
-  })
+  }
+
+  // ストアのアクションを呼び出し
+  const result = await planStore.createPlan(planData)
+
+  // 作成が成功したらトップページに遷移
+  if (result.success) {
+    router.push('/') // カレンダー画面のパスを指定
+  } else {
+    // エラー処理（今回はアラートで表示）
+    alert('予定の作成に失敗しました。\n' + (result.errors || []).join('\n'))
+  }
 }
 </script>
 
@@ -32,10 +59,7 @@ const handleSubmit = () => {
       <form @submit.prevent="handleSubmit">
         <!-- カテゴリ選択コンポーネントを組み込み -->
         <!-- v-model:selectedCategory を使用して、CategorySelectorからの選択をcategory変数にバインド -->
-        <CategorySelector
-          v-model:selected-category="category"
-          @update:selected-category="handleCategoryUpdate"
-        />
+        <CategorySelector :categories="authStore.categories" v-model="selectedCategoryObject" />
 
         <!-- 開始日時 -->
         <div class="mb-4">

--- a/frontend/src/views/ScheduleView.vue
+++ b/frontend/src/views/ScheduleView.vue
@@ -1,7 +1,11 @@
 <script setup>
+import { onMounted } from 'vue'
 import TheHeader from '../components/TheHeader.vue'
 import TimeAxis from '../components/TimeAxis.vue'
 import ScheduleColumn from '../components/ScheduleColumn.vue'
+import { usePlanStore } from '@/stores/plan'
+
+const planStore = usePlanStore()
 
 // --- 予定のモックデータ ---
 const plannedEvents = [
@@ -70,6 +74,11 @@ const actualEvents = [
     endTime: new Date('2025-06-26T17:05:00'), // さらに短い実績
   },
 ]
+
+onMounted(() => {
+  const today = new Date().toISOString().split('T')[0]
+  planStore.fetchPlans(today)
+})
 </script>
 
 <template>

--- a/frontend/src/views/ScheduleView.vue
+++ b/frontend/src/views/ScheduleView.vue
@@ -7,40 +7,6 @@ import { usePlanStore } from '@/stores/plan'
 
 const planStore = usePlanStore()
 
-// --- 予定のモックデータ ---
-const plannedEvents = [
-  {
-    id: 1,
-    category: '開発',
-    startTime: new Date('2025-06-26T09:00:00'),
-    endTime: new Date('2025-06-26T10:30:00'),
-  },
-  {
-    id: 2,
-    category: '休憩',
-    startTime: new Date('2025-06-26T12:00:00'),
-    endTime: new Date('2025-06-26T12:30:00'),
-  },
-  {
-    id: 3,
-    category: '学習',
-    startTime: new Date('2025-06-26T14:00:00'),
-    endTime: new Date('2025-06-26T16:00:00'),
-  },
-  {
-    id: 4,
-    category: 'ミーティング',
-    startTime: new Date('2025-06-26T08:00:00'),
-    endTime: new Date('2025-06-26T08:45:00'),
-  },
-  {
-    id: 5,
-    category: '短い予定',
-    startTime: new Date('2025-06-26T17:00:00'),
-    endTime: new Date('2025-06-26T17:15:00'),
-  },
-]
-
 // --- 実績のモックデータ ---
 const actualEvents = [
   {
@@ -96,7 +62,7 @@ onMounted(() => {
         <TimeAxis />
       </div>
       <div class="w-[700px] min-h-[1216px] flex-grow bg-white border-x-2 border-slate-300">
-        <ScheduleColumn title="予定" :events="plannedEvents" />
+        <ScheduleColumn title="予定" :events="planStore.plans" />
       </div>
       <div class="w-[700px] min-h-[1216px] flex-grow bg-white">
         <ScheduleColumn title="実績" :events="actualEvents" />


### PR DESCRIPTION
# What

バックエンドで実装した`plans` APIおよび`categories` APIとフロントエンドを接続し、ユーザーが「予定」を閲覧・作成できるコア機能を実装た。
具体的なタスクは以下のとおり。

- **状態管理 (Pinia)**
    - `plan` ストアを新設し、予定データと表示日付を一元管理
    - `auth` ストアに、APIから取得したカテゴリ一覧を保持する機能を追加

- **API連携**
    - `plans#index` (一覧取得), `plans#create` (新規作成), `categories#index` (カテゴリ一覧) の各APIとフロントエンドを連携
    - `axios` のリクエストにJWT認証トークンを付与し、認証が必要なAPIを呼び出せるように修正

- **画面実装 (Vue.js)**
    - カレンダー画面で、静的なモックデータの代わりに、APIから取得した動的な予定データを表示
    - ヘッダーに「今日」「前日」「翌日」ボタンを実装し、日付を切り替えてデータを再取得できるようにした
    - イベント作成フォームを実装し、新規予定を登録できるようにした
    - カテゴリ選択コンポーネントを、APIから取得した動的なデータで表示するように改修

- **その他**
    - `jsonapi-serializer` を全面的に採用し、すべてのAPIレスポンス形式を統一
    - `seeds.rb` を利用して、アイコン情報を含むカテゴリの初期データを投入できるようにした
    - 認証周りやタイムゾーンの扱いに関する複数のバグを修正

# Why

アプリケーションのコア機能である「予定の可視化」と「予定の作成」をユーザーが実際に行えるようにするため
バックエンドとフロントエンドを接続し、SPAとしての一連のデータフローを完成させることで、今後の機能拡張（更新・削除・実績機能）の土台を築く

## 補足

- 「予定」の更新・削除機能は、次以降のブランチで実装する予定
- 「実績」機能は、現時点では静的なモックデータを表示している