### PR TITLE
# Feat: 実績の表示機能と関連バグの修正

### DIFF
--- a/app/controllers/api/v1/actuals_controller.rb
+++ b/app/controllers/api/v1/actuals_controller.rb
@@ -5,6 +5,27 @@ module Api
     class ActualsController < ApplicationController
       before_action :authenticate_user!
 
+      def index
+        # フロントエンドから送られてきた日付パラメータを取得する
+        # パラメータがなければ、今日の日付をデフォルト値として使用する
+        date = params[:date] ? Date.parse(params[:date]) : Date.current
+
+        # 取得した日付の範囲（その日の開始から終了まで）を定義する
+        day_start = date.beginning_of_day
+        day_end = date.end_of_day
+
+        # ログイン中のユーザーに紐づく実績の中から、指定された日付範囲に合致するものを取得する
+        # includes(:category) を使って、N+1問題を回避しつつカテゴリ情報も同時に取得する
+        actuals = current_user.actuals.includes(:category).where('start_time <= ? AND end_time >= ?', day_end, day_start)
+
+        # シリアライザを呼び出すためのオプションを設定する
+        # これにより、Actualに紐づくCategoryの情報もレスポンスに含めることができる
+        options = { include: [:category] }
+
+        # シリアライザを使ってデータをJSON形式に整形し、フロントエンドに返す
+        render json: Api::V1::ActualSerializer.new(actuals, options).serializable_hash
+      end
+
       def create
         actual = current_user.actuals.build(actual_params)
         if actual.save

--- a/frontend/src/views/ScheduleView.vue
+++ b/frontend/src/views/ScheduleView.vue
@@ -1,19 +1,32 @@
 <script setup>
-import { onMounted } from 'vue'
+import { onMounted, watch } from 'vue'
 import TheHeader from '../components/TheHeader.vue'
 import TimeAxis from '../components/TimeAxis.vue'
 import ScheduleColumn from '../components/ScheduleColumn.vue'
 import { usePlanStore } from '@/stores/plan'
 import { useActualStore } from '@/stores/actual'
+import { useAuthStore } from '@/stores/auth'
 import PlanDetailModal from '../components/PlanDetailModal.vue'
 
 const planStore = usePlanStore()
 const actualStore = useActualStore()
+const authStore = useAuthStore()
 
-onMounted(() => {
-  const today = new Date().toISOString().split('T')[0]
-  Promise.all([planStore.fetchPlans(today), actualStore.fetchActuals(today)])
-})
+watch(
+  // 監視対象のデータ
+  () => authStore.isLoggedIn,
+  // 監視対象のデータが変化したときに実行される関数
+  (isLoggedIn) => {
+    // ログイン状態が true になった瞬間にデータを取得する
+    if (isLoggedIn) {
+      const dateToFetch = planStore.currentDate
+      Promise.all([planStore.fetchPlans(dateToFetch), actualStore.fetchActuals(dateToFetch)])
+    }
+  },
+  // { immediate: true } オプションにより、コンポーネントがマウントされた直後にも、watch内の処理が一度だけ実行される。
+  // これにより、すでにログイン済みの状態でページをリロードした場合にも対応できます。
+  { immediate: true },
+)
 
 // イベントを処理してモーダルを開く関数を定義
 const handlePlanClick = (plan) => {

--- a/frontend/src/views/ScheduleView.vue
+++ b/frontend/src/views/ScheduleView.vue
@@ -4,47 +4,15 @@ import TheHeader from '../components/TheHeader.vue'
 import TimeAxis from '../components/TimeAxis.vue'
 import ScheduleColumn from '../components/ScheduleColumn.vue'
 import { usePlanStore } from '@/stores/plan'
+import { useActualStore } from '@/stores/actual'
 import PlanDetailModal from '../components/PlanDetailModal.vue'
 
 const planStore = usePlanStore()
-
-// --- 実績のモックデータ ---
-const actualEvents = [
-  {
-    id: 101,
-    category: '開発 (実績)',
-    startTime: new Date('2025-06-26T09:15:00'), // 予定より少し遅れて開始
-    endTime: new Date('2025-06-26T10:45:00'),
-  },
-  {
-    id: 102,
-    category: '休憩 (実績)',
-    startTime: new Date('2025-06-26T12:00:00'),
-    endTime: new Date('2025-06-26T12:45:00'), // 予定より長めに休憩
-  },
-  {
-    id: 103,
-    category: '学習 (実績)',
-    startTime: new Date('2025-06-26T14:30:00'), // 予定より遅れて開始
-    endTime: new Date('2025-06-26T16:00:00'),
-  },
-  {
-    id: 104,
-    category: 'ミーティング (実績)',
-    startTime: new Date('2025-06-26T08:00:00'),
-    endTime: new Date('2025-06-26T08:30:00'), // 予定より早く終了
-  },
-  {
-    id: 105,
-    category: '短い予定 (実績)',
-    startTime: new Date('2025-06-26T17:00:00'),
-    endTime: new Date('2025-06-26T17:05:00'), // さらに短い実績
-  },
-]
+const actualStore = useActualStore()
 
 onMounted(() => {
   const today = new Date().toISOString().split('T')[0]
-  planStore.fetchPlans(today)
+  Promise.all([planStore.fetchPlans(today), actualStore.fetchActuals(today)])
 })
 
 // イベントを処理してモーダルを開く関数を定義
@@ -72,7 +40,7 @@ const handlePlanClick = (plan) => {
         <ScheduleColumn title="予定" :events="planStore.plans" @plan-click="handlePlanClick" />
       </div>
       <div class="w-[700px] min-h-[1216px] flex-grow bg-white">
-        <ScheduleColumn title="実績" :events="actualEvents" />
+        <ScheduleColumn title="実績" :events="actualStore.actuals" />
       </div>
     </div>
   </div>


### PR DESCRIPTION
# What

データベースに保存されている「実績」をカレンダー画面に表示する機能と、その過程で発見されたデータ表示に関するバグを修正した。

具体的なタスクは以下のとおり。

## バックエンド (Rails API)

- `GET /api/v1/actuals` のエンドポイントを実装し、指定された日付の実績データを返せるようにした。

## フロントエンド (Vue.js)

- **状態管理(Pinia)**: `planStore`の日付変更アクションを改修し、予定データと同時に実績データも取得するように連携を強化した。
- **画面表示**: `ScheduleView.vue`で`actualStore`から実績データを取得し、カレンダーの「実績」カラムに正しく描画するようにした。
- **バグ修正**: ページの初回表示やリロード時に、認証状態の確定を待ってからデータ取得処理を開始するように`watch`を用いて修正した。これにより、データが表示されない不具合を解消した。

# Why

- **機能追加**: アプリケーションのコア機能である「予定と実績の比較」を実現するため、作成済みの実績を可視化する必要があった。今回の実装により、ユーザーは日々の活動記録をカレンダー上で直感的に確認できるようになる。
- **品質向上**: リロード時にデータが表示されないというバグは、ユーザー体験を著しく損なう問題だった。この原因を特定し修正することで、アプリケーションの安定性と信頼性を向上させた。

## 補足

- このプルリクエストにより、「実績」のCRUD（作成・読み取り・更新・削除）のうち、「読み取り(Read)」の機能が完了します。
- 次のブランチでは、「実績の更新・削除機能」の実装に進む予定です。