### PR TITLE
Feat: 実績の更新・削除機能の実装

### DIFF
--- a/app/controllers/api/v1/actuals_controller.rb
+++ b/app/controllers/api/v1/actuals_controller.rb
@@ -4,6 +4,7 @@ module Api
   module V1
     class ActualsController < ApplicationController
       before_action :authenticate_user!
+      before_action :set_actual, only: %i[update destroy]
 
       def index
         # フロントエンドから送られてきた日付パラメータを取得する
@@ -35,7 +36,24 @@ module Api
         end
       end
 
+      def update
+        if @actual.update(actual_params)
+          render json: Api::V1::ActualSerializer.new(@actual).serializable_hash, status: :ok
+        else
+          render json: { errors: @actual.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      def destroy
+        @actual.destroy
+        head :no_content
+      end
+
       private
+
+      def set_actual
+        @actual = current_user.actuals.find(params[:id])
+      end
 
       def actual_params
         params.require(:actual).permit(:memo, :start_time, :end_time, :category_id)

--- a/frontend/src/components/ActualDetailModal.vue
+++ b/frontend/src/components/ActualDetailModal.vue
@@ -1,0 +1,175 @@
+<script setup>
+import { ref, watch } from 'vue'
+import { useActualStore } from '@/stores/actual'
+import { useAuthStore } from '@/stores/auth'
+import CategorySelector from '@/components/CategorySelector.vue'
+
+// --- ヘルパー関数 ---
+// Dateオブジェクトを <input type="datetime-local"> が解釈できる形式に変換する
+const toLocalISOString = (date) => {
+  if (!(date instanceof Date)) {
+    return ''
+  }
+  const year = date.getFullYear()
+  const month = (date.getMonth() + 1).toString().padStart(2, '0')
+  const day = date.getDate().toString().padStart(2, '0')
+  const hours = date.getHours().toString().padStart(2, '0')
+  const minutes = date.getMinutes().toString().padStart(2, '0')
+  return `${year}-${month}-${day}T${hours}:${minutes}`
+}
+
+// 親コンポーネントから'actual'という名前でデータを受け取る
+const props = defineProps({
+  actual: {
+    type: Object,
+    required: true, // 必須項目に設定
+  },
+})
+
+// ストアをインスタンス化
+const actualStore = useActualStore()
+const authStore = useAuthStore()
+
+const selectedCategoryObject = ref(null)
+const startTime = ref('')
+const endTime = ref('')
+const memo = ref('')
+
+// watchを使って、props.actualが変更されるたびにフォームの値を更新する
+watch(
+  [() => props.actual, () => authStore.categories],
+  ([newActual, categories]) => {
+    // actualデータがあり、かつ、カテゴリ一覧が取得済みの時だけ処理を実行
+    if (newActual && categories.length > 0) {
+      selectedCategoryObject.value = categories.find(
+        (c) => String(c.id) === String(newActual.category.id), // 両方を文字列に変換して比較するように修正
+      )
+      // 日時は 'YYYY-MM-DDTHH:mm' 形式の文字列に変換する
+      startTime.value = toLocalISOString(newActual.startTime)
+      endTime.value = toLocalISOString(newActual.endTime)
+      memo.value = newActual.memo
+    }
+  },
+  { immediate: true }, // コンポーネントの初回表示時にも即時実行するオプション
+)
+
+// --- イベントハンドラ ---
+/**
+ * 更新ボタンがクリックされたときの処理
+ */
+const handleUpdate = async () => {
+  if (!selectedCategoryObject.value) {
+    alert('カテゴリを選択してください。')
+    return
+  }
+
+  const actualData = {
+    id: props.actual.id, // 更新対象のIDを忘れずに含める
+    category_id: selectedCategoryObject.value.id,
+    start_time: startTime.value,
+    end_time: endTime.value,
+    memo: memo.value,
+  }
+
+  const result = await actualStore.updateActual(actualData)
+  if (!result.success) {
+    alert('実績の更新に失敗しました。\n' + (result.errors || []).join('\n'))
+  }
+}
+
+/**
+ * 削除ボタンがクリックされたときの処理
+ */
+const handleDelete = async () => {
+  // ユーザーに最終確認
+  if (window.confirm('この実績を本当に削除しますか？')) {
+    const result = await actualStore.deleteActual(props.actual.id)
+    if (!result.success) {
+      alert('実績の削除に失敗しました。\n' + (result.errors || []).join('\n'))
+    }
+  }
+}
+
+// モーダルを閉じるための関数
+const closeModal = () => {
+  actualStore.closeActualModal()
+}
+</script>
+
+<template>
+  <div
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
+    @click.self="closeModal"
+  >
+    <div class="bg-white p-8 rounded-lg shadow-lg w-full max-w-3xl">
+      <h2 class="text-2xl font-bold text-center mb-6">実績の詳細・編集</h2>
+      <!-- formのsubmitイベントでhandleUpdateを呼び出す -->
+      <form @submit.prevent="handleUpdate">
+        <!-- v-modelでローカル変数とフォームをバインド -->
+        <CategorySelector :categories="authStore.categories" v-model="selectedCategoryObject" />
+
+        <!-- 開始日時 -->
+        <div class="mb-4">
+          <label for="startTime" class="block text-gray-700 text-sm font-bold mb-2">開始日時</label>
+          <input
+            id="startTime"
+            v-model="startTime"
+            type="datetime-local"
+            class="shadow appearance-none border rounded-lg w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+            required
+          />
+        </div>
+
+        <!-- 終了日時 -->
+        <div class="mb-4">
+          <label for="endTime" class="block text-gray-700 text-sm font-bold mb-2">終了日時</label>
+          <input
+            id="endTime"
+            v-model="endTime"
+            type="datetime-local"
+            class="shadow appearance-none border rounded-lg w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+            required
+          />
+        </div>
+
+        <!-- メモ -->
+        <div class="mb-4">
+          <label for="memo" class="block text-gray-700 text-sm font-bold mb-2">メモ（任意）</label>
+          <textarea
+            id="memo"
+            v-model="memo"
+            rows="4"
+            class="shadow appearance-none border rounded-lg w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline resize-y"
+            placeholder="イベントの詳細やメモを入力"
+          ></textarea>
+        </div>
+
+        <div class="flex items-center justify-between mt-6">
+          <div>
+            <button
+              type="submit"
+              class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg focus:outline-none focus:shadow-outline"
+            >
+              更新
+            </button>
+            <!-- 削除ボタンのクリックイベントでhandleDeleteを呼び出す -->
+            <button
+              type="button"
+              class="bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded-lg focus:outline-none focus:shadow-outline ml-4"
+              @click="handleDelete"
+            >
+              削除
+            </button>
+          </div>
+          <button
+            type="button"
+            class="bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded-lg focus:outline-none focus:shadow-outline"
+            @click="closeModal"
+          >
+            キャンセル
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/ScheduleColumn.vue
+++ b/frontend/src/components/ScheduleColumn.vue
@@ -1,14 +1,14 @@
 <script setup>
 import EventBlock from './EventBlock.vue'
 
-const emit = defineEmits(['plan-click'])
+const emit = defineEmits(['plan-click', 'actual-click'])
 
 // 親からeventsデータを受け取るようにPropsを定義
-defineProps({
+const props = defineProps({
   title: String,
   events: {
     type: Array,
-    default: () => [], // デフォルト値として空の配列を設定
+    default: () => [],
   },
 })
 
@@ -49,11 +49,16 @@ const getEventStyle = (event) => {
 
 /**
  * クリックイベントを処理し、親コンポーネントに通知する関数
+ * props.titleに応じて、発行するイベントを切り替える。
  * @param {object} event - クリックされた予定オブジェクト
  */
-const handlePlanClick = (event) => {
-  // 'plan-click' という名前のイベントを発行し、クリックされた予定データを一緒に渡します。
-  emit('plan-click', event)
+const handleEventClick = (event) => {
+  if (props.title === '予定') {
+    // 'plan-click' という名前のイベントを発行し、クリックされた予定データを一緒に渡す。
+    emit('plan-click', event)
+  } else if (props.title === '実績') {
+    emit('actual-click', event)
+  }
 }
 </script>
 
@@ -63,14 +68,14 @@ const handlePlanClick = (event) => {
       {{ title }}
     </h2>
     <div v-for="n in 24" :key="n" class="h-12 pr-2 border-b border-gray-200"></div>
-    <!-- EventBlockがクリックされたらhandlePlanClickを呼び出す -->
+    <!-- EventBlockがクリックされたらhandleEventClickを呼び出す -->
     <EventBlock
       v-for="event in events"
       :key="event.id"
       :category-name="event.category?.name || event.memo"
       :time="`${formatTime(event.startTime)} - ${formatTime(event.endTime)}`"
       :style="getEventStyle(event)"
-      @click="handlePlanClick(event)"
+      @click="handleEventClick(event)"
       class="cursor-pointer"
     />
   </div>

--- a/frontend/src/stores/actual.js
+++ b/frontend/src/stores/actual.js
@@ -5,9 +5,27 @@ import { useAuthStore } from './auth'
 export const useActualStore = defineStore('actual', {
   state: () => ({
     actuals: [],
+    isModalOpen: false,
+    selectedActual: null,
   }),
 
   actions: {
+    /**
+     * 実績詳細モーダルを開くアクション
+     * @param {object} actual - 表示する実績オブジェクト
+     */
+    openActualModal(actual) {
+      this.selectedActual = actual
+      this.isModalOpen = true
+    },
+
+    /**
+     * 実績詳細モーダルを閉じるアクション
+     */
+    closeActualModal() {
+      this.isModalOpen = false
+      this.selectedActual = null
+    },
     async fetchActuals(date) {
       const authStore = useAuthStore()
       if (!authStore.token) {

--- a/frontend/src/stores/actual.js
+++ b/frontend/src/stores/actual.js
@@ -26,6 +26,7 @@ export const useActualStore = defineStore('actual', {
       this.isModalOpen = false
       this.selectedActual = null
     },
+
     async fetchActuals(date) {
       const authStore = useAuthStore()
       if (!authStore.token) {
@@ -42,16 +43,13 @@ export const useActualStore = defineStore('actual', {
         const response = await axios.get(`http://localhost:3000/api/v1/actuals?date=${date}`, {
           headers,
         })
-
         const actualData = response.data.data
         const includedData = response.data.included || []
-
         const categoryMap = new Map(
           includedData
             .filter((item) => item.type === 'category')
             .map((item) => [item.id, item.attributes]),
         )
-
         const formattedActuals = actualData.map((actual) => {
           const categoryId = actual.relationships.category.data.id
           const category = categoryMap.get(categoryId)
@@ -86,17 +84,14 @@ export const useActualStore = defineStore('actual', {
           // authStoreからトークンを取得するように変更
           Authorization: authStore.token,
         }
-
         const response = await axios.post(
           'http://localhost:3000/api/v1/actuals',
           { actual: newActual },
           { headers },
         )
-
         const newActualData = response.data.data
         const newCategoryId = newActualData.relationships.category.data.id
         const category = authStore.categories.find((c) => String(c.id) === String(newCategoryId))
-
         const formattedNewActual = {
           id: newActualData.id,
           ...newActualData.attributes,
@@ -107,12 +102,94 @@ export const useActualStore = defineStore('actual', {
             name: category ? category.name : '不明なカテゴリ',
           },
         }
-
         this.actuals.push(formattedNewActual)
         return { success: true }
       } catch (error) {
         console.error('実績の作成に失敗しました:', error.response?.data?.errors)
         return { success: false, errors: error.response?.data?.errors || ['作成に失敗しました'] }
+      }
+    },
+
+    /**
+     * 既存の実績を更新するアクション
+     * @param {object} actualData - { id, memo, start_time, end_time, category_id }
+     */
+    async updateActual(actualData) {
+      const authStore = useAuthStore()
+      if (!authStore.token) {
+        console.error('認証トークンがありません。')
+        return { success: false, errors: ['ログインしてください。'] }
+      }
+      // 更新対象のIDを分割代入で取り出しておく
+      const { id, ...updateData } = actualData
+
+      try {
+        const headers = {
+          Authorization: authStore.token,
+        }
+        // Rails APIが受け取る形式 { actual: { ... } } に合わせてデータを整形
+        const response = await axios.put(
+          `http://localhost:3000/api/v1/actuals/${id}`, // URLにIDを含める
+          { actual: updateData },
+          { headers },
+        )
+
+        // --- ここからが画面への即時反映処理 ---
+        const updatedActualData = response.data.data
+        const categoryId = updatedActualData.relationships.category.data.id
+        const category = authStore.categories.find((c) => String(c.id) === String(categoryId))
+        // APIからのレスポンスを、stateで管理している形式に再加工
+        const formattedUpdatedActual = {
+          id: updatedActualData.id,
+          ...updatedActualData.attributes,
+          startTime: new Date(updatedActualData.attributes.start_time),
+          endTime: new Date(updatedActualData.attributes.end_time),
+          category: {
+            id: categoryId,
+            name: category ? category.name : '不明なカテゴリ',
+          },
+        }
+        // stateのactuals配列から、更新したactualと同じIDのものを探し、そのインデックス番号を取得
+        const index = this.actuals.findIndex((a) => a.id === formattedUpdatedActual.id)
+        // もし見つかれば、その要素を新しいデータで置き換える
+        if (index !== -1) {
+          this.actuals[index] = formattedUpdatedActual
+        }
+        // --- ここまでが即時反映処理 ---
+
+        this.closeActualModal() // 最後にモーダルを閉じる
+        return { success: true }
+      } catch (error) {
+        console.error('実績の更新に失敗しました:', error.response?.data?.errors)
+        return { success: false, errors: error.response?.data?.errors }
+      }
+    },
+
+    /**
+     * 実績を削除するアクション
+     * @param {string} actualId - 削除する実績のID
+     */
+    async deleteActual(actualId) {
+      const authStore = useAuthStore()
+      if (!authStore.token) {
+        console.error('認証トークンがありません。')
+        return { success: false, errors: ['ログインしてください。'] }
+      }
+
+      try {
+        const headers = {
+          Authorization: authStore.token,
+        }
+        // DELETEリクエストを送信
+        await axios.delete(`http://localhost:3000/api/v1/actuals/${actualId}`, { headers })
+        // --- 画面への即時反映処理 ---
+        // state.actuals配列から、削除したIDと一致しないものだけをフィルタリングして新しい配列を作る
+        this.actuals = this.actuals.filter((a) => a.id !== actualId)
+        this.closeActualModal() // 最後にモーダルを閉じる
+        return { success: true }
+      } catch (error) {
+        console.error('実績の削除に失敗しました:', error.response?.data?.errors)
+        return { success: false, errors: error.response?.data?.errors }
       }
     },
   },

--- a/frontend/src/views/ScheduleView.vue
+++ b/frontend/src/views/ScheduleView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { onMounted, watch } from 'vue'
+import { watch } from 'vue'
 import TheHeader from '../components/TheHeader.vue'
 import TimeAxis from '../components/TimeAxis.vue'
 import ScheduleColumn from '../components/ScheduleColumn.vue'
@@ -7,6 +7,7 @@ import { usePlanStore } from '@/stores/plan'
 import { useActualStore } from '@/stores/actual'
 import { useAuthStore } from '@/stores/auth'
 import PlanDetailModal from '../components/PlanDetailModal.vue'
+import ActualDetailModal from '../components/ActualDetailModal.vue'
 
 const planStore = usePlanStore()
 const actualStore = useActualStore()
@@ -28,9 +29,20 @@ watch(
   { immediate: true },
 )
 
-// イベントを処理してモーダルを開く関数を定義
+/**
+ * 「予定」ブロックがクリックされたときの処理
+ * @param {object} plan - クリックされた予定オブジェクト
+ */
 const handlePlanClick = (plan) => {
   planStore.openPlanModal(plan)
+}
+
+/**
+ * 「実績」ブロックがクリックされたときの処理
+ * @param {object} actual - クリックされた実績オブジェクト
+ */
+const handleActualClick = (actual) => {
+  actualStore.openActualModal(actual)
 }
 </script>
 
@@ -53,17 +65,24 @@ const handlePlanClick = (plan) => {
         <ScheduleColumn title="予定" :events="planStore.plans" @plan-click="handlePlanClick" />
       </div>
       <div class="w-[700px] min-h-[1216px] flex-grow bg-white">
-        <ScheduleColumn title="実績" :events="actualStore.actuals" />
+        <ScheduleColumn
+          title="実績"
+          :events="actualStore.actuals"
+          @actual-click="handleActualClick"
+        />
       </div>
     </div>
   </div>
 
-  <!-- 
-    v-ifでモーダルを表示/非表示
-    :planで選択された予定データをPropsとして渡す
-  -->
+  <!-- 予定詳細モーダル -->
   <PlanDetailModal
     v-if="planStore.isModalOpen && planStore.selectedPlan"
     :plan="planStore.selectedPlan"
+  />
+
+  <!-- 実績詳細モーダル -->
+  <ActualDetailModal
+    v-if="actualStore.isModalOpen && actualStore.selectedActual"
+    :actual="actualStore.selectedActual"
   />
 </template>


### PR DESCRIPTION
# What

カレンダー画面上の「実績」ブロックをクリックすると詳細モーダルが開き、そこから実績の更新・削除ができる機能を実装した。
これにより、「実績」に関するCRUD機能がすべて完成した。

具体的なタスクは以下のとおり。

## バックエンド (Rails API)

- `ActualsController`に`update`と`destroy`アクションを追加し、実績の更新・削除リクエストを処理できるようにした。

## フロントエンド (Vue.js)

- **状態管理(Pinia)**: `actualStore`にモーダルの表示状態を管理する`state`と`actions`を追加。さらに、APIと連携して実績の更新・削除を行う`updateActual`, `deleteActual`アクションを実装した。
- **画面表示(Vue)**: `PlanDetailModal.vue`を参考に`ActualDetailModal.vue`を新規作成。`ScheduleColumn.vue`と`ScheduleView.vue`を修正し、実績ブロックのクリックイベントを捕捉して、対応するモーダルを開くように連携を実装した。

# Why

- **機能の完成**: これまで実装してきた「実績」の作成(Create)・表示(Read)機能に加え、今回の更新(Update)・削除(Delete)機能が揃ったことで、実績管理の基本機能（CRUD）が一通り完成した。
- **UXの向上**: ユーザーが登録した実績を、画面遷移なくスムーズに修正・削除できるようになり、アプリケーションの操作性が向上した。これにより、日々の活動記録をより柔軟に管理できるようになる。

## 補足

- このプルリクエストにより、「実績」のCRUD機能がすべて完了しました。
- 次のブランチでは、プロジェクトサマリーの残タスクである「日付またぎ表示の修正」や「入力値バリデーションの強化」に取り組む予定です。