### PR TITLE
Fix: 日付をまたぐイベントの表示を修正

### DIFF
--- a/frontend/src/components/EventBlock.vue
+++ b/frontend/src/components/EventBlock.vue
@@ -12,7 +12,8 @@ defineProps({
 </script>
 
 <template>
-  <div class="absolute inset-x-0 bg-blue-200 opacity-75 z-10 p-2 rounded flex items-center">
+  <!-- 親から計算された高さが30分未満の場合でも、最低30分の高さを保つようにする。 -->
+  <div class="absolute inset-x-0 bg-blue-200 opacity-75 z-10 p-2 rounded flex items-center min-h-6">
     <div class="flex items-center justify-between w-full">
       <p class="font-bold text-sm truncate">{{ categoryName }}</p>
       <p class="text-xs flex-shrink-0 ml-2">{{ time }}</p>

--- a/frontend/src/components/ScheduleColumn.vue
+++ b/frontend/src/components/ScheduleColumn.vue
@@ -1,5 +1,7 @@
 <script setup>
+import { computed } from 'vue'
 import EventBlock from './EventBlock.vue'
+import { usePlanStore } from '@/stores/plan'
 
 const emit = defineEmits(['plan-click', 'actual-click'])
 
@@ -12,14 +14,42 @@ const props = defineProps({
   },
 })
 
+const planStore = usePlanStore()
 // 各時間枠divの高さ (h-12 = 48px)
 const SLOT_HEIGHT = 48
 // h2タグの高さ (h-16 = 64px)
 const HEADER_HEIGHT = 64
 
+// props.eventsを直接使わず、日付またぎを考慮して加工したリストを生成する
+const processedEvents = computed(() => {
+  if (!planStore.currentDate) return []
+
+  // JSTでの今日の日付の開始時刻 (例: 2025-08-09 00:00:00 JST)
+  const dayStart = new Date(`${planStore.currentDate}T00:00:00`)
+  // JSTでの今日の日付の終了時刻 (例: 2025-08-09 23:59:59 JST)
+  const dayEnd = new Date(`${planStore.currentDate}T23:59:59.999`)
+
+  return props.events.map((event) => {
+    // バックエンド(UTC)から渡された日時文字列は、`new Date()`によってブラウザのローカルタイム(JST)に変換される。
+    // そのため、ここからの日時の比較や加工はすべてJST基準で行われる。
+
+    // イベントの開始時刻を、今日より前なら今日の開始時刻に、そうでなければ元の時刻に切り詰める(clamp)
+    const clampedStartTime = new Date(Math.max(dayStart.getTime(), event.startTime.getTime()))
+    // イベントの終了時刻を、今日より後なら今日の終了時刻に、そうでなければ元の時刻に切り詰める(clamp)
+    const clampedEndTime = new Date(Math.min(dayEnd.getTime(), event.endTime.getTime()))
+
+    // 元のイベント情報を引き継ぎつつ、表示用の開始・終了時刻を上書きした新しいオブジェクトを返す
+    return {
+      ...event,
+      startTime: clampedStartTime,
+      endTime: clampedEndTime,
+    }
+  })
+})
+
 const formatTime = (date) => {
   if (!date || !(date instanceof Date)) return ''
-  // getHours()とgetMinutes()はブラウザのローカルタイム（日本時間）を返すので、ここでタイムゾーンが正しく扱われます
+  // getHours()とgetMinutes()はブラウザのローカルタイム（日本時間）を返すので、ここでタイムゾーンが正しく扱われる
   const hours = date.getHours().toString().padStart(2, '0')
   const minutes = date.getMinutes().toString().padStart(2, '0')
   return `${hours}:${minutes}`
@@ -33,7 +63,10 @@ const getEventStyle = (event) => {
   const totalStartMinutes = startHour * 60 + startMinutes // 00:00からの総分数
 
   // 終了時刻と開始時刻の差分から高さを計算
+  // clampedEndTimeが23:59:59.999の場合があるので、getTime()の差分で正確に計算する
   let durationMinutes = (event.endTime.getTime() - event.startTime.getTime()) / (1000 * 60)
+  // 差分が0に近くなる場合も考慮し、最低でも1分は確保する
+  durationMinutes = Math.max(durationMinutes, 1)
 
   // 最低30分の高さ
   durationMinutes = Math.max(durationMinutes, 30)
@@ -70,7 +103,7 @@ const handleEventClick = (event) => {
     <div v-for="n in 24" :key="n" class="h-12 pr-2 border-b border-gray-200"></div>
     <!-- EventBlockがクリックされたらhandleEventClickを呼び出す -->
     <EventBlock
-      v-for="event in events"
+      v-for="event in processedEvents"
       :key="event.id"
       :category-name="event.category?.name || event.memo"
       :time="`${formatTime(event.startTime)} - ${formatTime(event.endTime)}`"

--- a/frontend/src/components/ScheduleColumn.vue
+++ b/frontend/src/components/ScheduleColumn.vue
@@ -68,9 +68,6 @@ const getEventStyle = (event) => {
   // 差分が0に近くなる場合も考慮し、最低でも1分は確保する
   durationMinutes = Math.max(durationMinutes, 1)
 
-  // 最低30分の高さ
-  durationMinutes = Math.max(durationMinutes, 30)
-
   const topPosition = HEADER_HEIGHT + (totalStartMinutes / 60) * SLOT_HEIGHT
   const eventHeight = (durationMinutes / 60) * SLOT_HEIGHT
 


### PR DESCRIPTION
# What

カレンダー上で日付をまたぐ予定や実績が正しく表示されない不具合を修正した。
また、関連するコンポーネントの責務を明確にするため、イベントブロックの高さ計算ロジックをリファクタリングした。

具体的なタスクは以下のとおり。

## 表示ロジックの修正 (ScheduleColumn.vue)

- Vueの`computed`プロパティを導入し、親から受け取ったイベントリストを加工する`processedEvents`を実装した。
- この中で、各イベントの開始・終了時刻を、その日に表示すべき範囲内に「切り詰める(clamp)」処理を行い、日付をまたぐイベントが各日に分割して表示されるようにした。

## リファクタリング (ScheduleColumn.vue / EventBlock.vue)

- イベントの最低限の高さを保証する責務を、`ScheduleColumn.vue`から`EventBlock.vue`に移譲した。
  - `ScheduleColumn.vue`の`getEventStyle`からは、最低高さを保証するロジックを削除。
  - `EventBlock.vue`に`min-h-6`クラスを追加し、コンポーネント自身が見た目の最低高さを担保するように修正。

# Why

- **UXの向上**: これまで表示が崩れていた、夜間や複数日にわたるイベントが正しく表示されるようになり、カレンダーアプリケーションとしての基本的な品質が向上した。
- **保守性の向上**: コンポーネントの「関心の分離」を徹底し、それぞれの責務を明確にした。`ScheduleColumn`は時間軸の計算、`EventBlock`は自身の見た目に責任を持つという美しい設計になり、今後のメンテナンスが容易になる。

## 補足

- このプルリクエストにより、【デプロイ準備】のフェーズが完了します。
- 次のブランチでは、次のフェーズの「総合テスト」に進む予定です。