### PR TITLE
Fix: デプロイ失敗の原因となるGemfileを修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,9 +6,6 @@ ruby '3.2.0'
 
 gem 'rails', '~> 7.1.5', '>= 7.1.5.1'
 
-# データベース
-gem 'mysql2', '~> 0.5'
-
 # API関連のGem
 gem 'devise'
 gem 'devise-jwt'
@@ -30,6 +27,7 @@ gem 'bootsnap', require: false
 
 # 開発環境とテスト環境でのみ使用するGem
 group :development, :test do
+  gem 'mysql2', '~> 0.5'
   gem 'dotenv-rails'
   gem 'debug', platforms: %i[mri windows]
   gem 'rspec-rails', '~> 6.1'


### PR DESCRIPTION
# What

本番環境(Render)で不要な `mysql2` gem がインストールされようとしてビルドに失敗する問題を解決するため、`Gemfile` を修正した。

- `mysql2` gem を `:development, :test` グループ内に移動させた。
- 上記変更に伴い `bundle install` を実行し、`Gemfile.lock` を更新した。

# Why

開発環境(MySQL)と本番環境(PostgreSQL)で使用するデータベースが異なるため、それぞれの環境で必要なgemのみがインストールされるように依存関係を明確にする必要があったため。

この修正により、Renderでのデプロイが正常に実行されるようになる。