### PR TITLE
Fix: 本番環境のデータベース接続設定を修正

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -49,7 +49,6 @@ test:
 # for a full overview on how database connection configuration can be specified.
 #
 production:
-  <<: *default
   adapter: postgresql
   encoding: unicode
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>


### PR DESCRIPTION
# What

本番環境(Render)で`db:migrate`を実行する際に、データベースへの接続に失敗してビルドがエラーになる問題を修正した。

- `config/database.yml`の`production:`ブロックが、ローカル開発用の`socket:`設定を継承しないように修正した。

# Why

`default:`設定から継承していた`socket:`キーが原因で、アプリケーションがRenderのデータベース（ネットワーク接続）ではなく、ローカルのソケットファイルを探しに行ってしまい、`PG::ConnectionBad`エラーが発生していた。

この修正により、本番環境で正しく`DATABASE_URL`環境変数が参照され、データベースに接続できるようになる。