### PR TITLE
fix: 不要なsprockets-rails gemを削除

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,6 @@ gem 'puma', '>= 5.0'
 
 # Railsの基本機能
 gem 'jbuilder'
-gem 'sprockets-rails'
 
 # Windows用の設定
 gem 'tzinfo-data', platforms: %i[windows jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -315,14 +315,6 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    sprockets (4.2.2)
-      concurrent-ruby (~> 1.0)
-      logger
-      rack (>= 2.2.4, < 4)
-    sprockets-rails (3.5.2)
-      actionpack (>= 6.1)
-      activesupport (>= 6.1)
-      sprockets (>= 3.0.0)
     stringio (3.1.7)
     thor (1.3.2)
     timeout (0.4.3)
@@ -382,7 +374,6 @@ DEPENDENCIES
   rubocop
   rubocop-rails
   selenium-webdriver
-  sprockets-rails
   tzinfo-data
   web-console
 


### PR DESCRIPTION
# What

Renderへのデプロイ時に`Could not find gem 'sprockets-rails'`というエラーでビルドが失敗する問題を解決するため、`Gemfile`から`sprockets-rails`を削除した。

## Why

このアプリケーションはAPI専用モードであり、`sprockets-rails`は不要。このgemが`Gemfile`に残っていたことが、デプロイ時の依存関係解決エラーの原因だった。