### PR TITLE
Fix: APIモードで不要なjbuilder gemを削除

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,9 +15,6 @@ gem 'rack-cors'
 # Webサーバー
 gem 'puma', '>= 5.0'
 
-# Railsの基本機能
-gem 'jbuilder'
-
 # Windows用の設定
 gem 'tzinfo-data', platforms: %i[windows jruby]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,9 +142,6 @@ GEM
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    jbuilder (2.13.0)
-      actionview (>= 5.0.0)
-      activesupport (>= 5.0.0)
     json (2.12.2)
     jsonapi-serializer (2.2.0)
       activesupport (>= 4.2)
@@ -363,7 +360,6 @@ DEPENDENCIES
   devise-jwt
   dotenv-rails
   foreman
-  jbuilder
   jsonapi-serializer
   mysql2 (~> 0.5)
   pg


### PR DESCRIPTION
# What

Renderへのデプロイ時に `Could not find 'jbuilder'` というエラーでビルドが失敗する問題を解決するため、`Gemfile`から`jbuilder`を削除した。

# Why

このアプリケーションはAPI専用モードであり、JSONの生成には`jsonapi-serializer`を使用しているため、`jbuilder`は不要。この不要なgemが`Gemfile`に残っていたことが、デプロイ時の依存関係解決エラーの原因だった。

この修正により、ビルドプロセスが正常に完了することが期待される。