### PR TITLE
Fix: db:seed実行時のJTIエラーを修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,4 +13,15 @@ class User < ApplicationRecord
   has_many :actuals, dependent: :destroy
 
   validates :name, presence: true
+
+  # db:seed実行時にjtiが自動で設定されずにエラーになる問題への対策として、
+  # Userレコードが作成される直前に、必ずjtiを生成するコールバックを追加。
+  before_create :set_jti
+
+  private
+
+  def set_jti
+    # self.jtiに値がセットされていない場合のみ、新しいUUIDを生成してセットする
+    self.jti ||= SecureRandom.uuid
+  end
 end


### PR DESCRIPTION
# What

Renderへのデプロイ時に`db:seed`タスクで`undefined method 'jti'`エラーが発生し、ビルドが失敗する問題を修正した。

- `User`モデルに`before_create`コールバックを追加し、レコード作成時に`jti`カラムが必ず設定されるようにした。

# Why

`devise-jwt`は`jti`カラムを必要としますが、`db:seed`の実行コンテキストでは`jti`が自動で生成されないケースがあった。
このコールバックを追加することで、どのような状況でユーザーが作成されても`jti`の存在が保証され、デプロイ時の`db:seed`が正常に完了するようになる。