### PR TITLE
fix: create_plansマイグレーションファイルのSyntaxErrorを修正

### DIFF
--- a/db/migrate/20250711085445_create_plans.rb
+++ b/db/migrate/20250711085445_create_plans.rb
@@ -10,4 +10,3 @@ class CreatePlans < ActiveRecord::Migration[7.1]
     end
   end
 end
-


### PR DESCRIPTION
# What

Renderへのデプロイ時に`db:migrate`が`SyntaxError`で失敗する根本原因を解決するため、マイグレーションファイルを修正した。

- `db/migrate/20250711085445_create_plans.rb`ファイルの末尾に存在した、不正な制御文字を削除した。

# Why

ファイルの末尾に紛れ込んだ目に見えない制御文字が原因で、Rubyがファイルを正しく解釈できず、`SyntaxError`が発生していた。これにより`db:migrate`コマンドが失敗し、データベースにテーブルが一切作成されないことが、これまでのすべてのデプロイ失敗の根本的な原因だったと思われる。

この修正により、`db:migrate`が正常に完了し、ビルドプロセス全体が成功することが期待される。