### PR TITLE
Fix: 不要なAction Cable関連ファイルを削除

### DIFF
--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-module ApplicationCable
-  class Channel < ActionCable::Channel::Base
-  end
-end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-module ApplicationCable
-  class Connection < ActionCable::Connection::Base
-  end
-end


### PR DESCRIPTION
# What

Renderへのデプロイ時に `uninitialized constant ApplicationCable::ActionCable` というエラーで起動に失敗する問題を解決するため、不要なディレクトリを削除した。

- `app/channels` ディレクトリをプロジェクトから完全に削除した。

# Why

このアプリケーションはAPI専用モードであり、リアルタイム通信機能であるAction Cableを使用していない。しかし、プロジェクト初期に自動生成された`app/channels`ディレクトリが残っていたため、Railsの起動プロセス中に存在しない`ActionCable`モジュールを読み込もうとして`NameError`が発生していたため。