### PR TITLE
Fix: DeviseコントローラーでBasic認証をスキップ

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::API
-  # Rails APIモードではデフォルトで読み込まれないBasic認証の機能を手動でインクルード。
+  # Rails APIモードではデフォルトで読み込まれないBasic認証の機能を手動でインクルード
   include ActionController::HttpAuthentication::Basic::ControllerMethods
 
   # 本番環境(production)の場合のみ、Basic認証を実行するように設定する。
@@ -9,6 +9,9 @@ class ApplicationController < ActionController::API
   if Rails.env.production?
     http_basic_authenticate_with name: ENV.fetch('BASIC_AUTH_USER'), password: ENV.fetch('BASIC_AUTH_PASSWORD')
   end
+
+  # Deviseのコントローラーの場合、Basic認証をスキップします。
+  skip_before_action :authenticate, if: :devise_controller?
 
   before_action :configure_permitted_parameters, if: :devise_controller?
 


### PR DESCRIPTION
# What

本番環境で新規登録やログインができない問題を解決するため、`ApplicationController`を修正した。

- `skip_before_action`を使い、Devise関連のコントローラー（新規登録、ログインなど）が実行される際には、Basic認証をスキップするように設定した。

# Why

アプリケーション全体にかけたBasic認証が、Deviseの認証API（新規登録やログイン）までブロックしてしまい、ユーザーがアカウントを作成・利用できない状態だったため。

この修正により、一般のAPIはBasic認証で保護しつつ、認証機能自体は正しく動作するようになることを期待する。