### PR TITLE
Fix: 本番環境でのJWT認証エラーを修正

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -311,7 +311,7 @@ Devise.setup do |config|
   # changed. Defaults to true, so a user is signed in automatically after changing a password.
   # config.sign_in_after_change_password = true
   config.jwt do |jwt|
-    jwt.secret = Rails.application.credentials.devise_jwt_secret_key
+    jwt.secret = ENV['DEVISE_JWT_SECRET_KEY']
     jwt.dispatch_requests = [
       ['POST', %r{^/users/sign_in$}],
     ]


### PR DESCRIPTION
# What

本番環境(Render)でログイン後にAPI通信が401エラーで失敗する問題を解決するため、`devise-jwt`の秘密鍵の管理方法を変更した。

- `config/initializers/devise.rb`を修正し、JWTの秘密鍵を`credentials`からではなく、`DEVISE_JWT_SECRET_KEY`という環境変数から直接読み込むように変更した。

# Why

`credentials`を利用する方法は、`RAILS_MASTER_KEY`の管理が別途必要となり、デプロイ時の設定が複雑化する原因だった。環境変数で直接管理することで、ローカルと本番環境で同じ秘密鍵を確実かつシンプルに共有でき、署名の検証が正しく行われるようになる。