### PR TITLE
Chore: デプロイ時にdb:seedを実行するよう修正

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -8,3 +8,6 @@ bundle install
 # データベースのマイグレーションを実行する
 # (テーブル構造を本番DBに反映させるための最重要コマンド)
 bundle exec rake db:migrate
+
+# 初期データを投入する
+bundle exec rake db:seed


### PR DESCRIPTION
# What

本番環境でカテゴリ一覧が表示されない問題を解決するため、Renderのビルドスクリプトを修正した。

- `bin/render-build.sh` に `bundle exec rake db:seed` を追加し、デプロイ時に初期データが投入されるようにした。

# Why

Renderのデータベースはデプロイ時に空の状態で作成されるため、`db:seed`を実行してカテゴリなどの初期データを投入する必要があるため。